### PR TITLE
Fix typo and update content type in GreetingsAdapter.java

### DIFF
--- a/java/open-banking-demo-app/src/main/java/com/ing/developer/app/apis/greetings/GreetingsAdapter.java
+++ b/java/open-banking-demo-app/src/main/java/com/ing/developer/app/apis/greetings/GreetingsAdapter.java
@@ -38,7 +38,7 @@ public class GreetingsAdapter {
     public String getGreetingJWS() {
         try {
             greetingsApi.getApiClient().setMTLSPinning(true).setJwsSigning(true);
-            return greetingsApi.signedGreetingsGet(APPLICATION_FORM_URLENCODED, null, null).getMessage();
+            return greetingsApi.signedGreetingsGet(MediaType.APPLICATION_FORM_URLENCODED, null, null).getMessage();
         } catch (ApiException e) {
             return throwInternalizedException(e.getCode(), "greetings", e);
         }


### PR DESCRIPTION
Fix typo and update content type in GreetingsAdapter.java

- Corrected the usage of `MediaType.APPLICATION_FORM_URLENCODED` in the `GreetingsAdapter` class.
- This ensures that the JWS endpoint correctly specifies the media type.

This change addresses an issue where the content type was not being set correctly for the JWS endpoint.